### PR TITLE
feat: add delay for resume from a suspend

### DIFF
--- a/src/util/pluginMain.ts
+++ b/src/util/pluginMain.ts
@@ -180,10 +180,12 @@ export class PluginManager{
     Settings.loadSettingsFromLocalStorage();
     Backend.applySettings(APPLYTYPE.SET_ALL);
     PluginManager.suspendEndHook = SteamClient.System.RegisterForOnResumeFromSuspend(async () => {
-      if (Settings.ensureEnable()) {
-        Backend.throwSuspendEvt()
-      }
-      Backend.applySettings(APPLYTYPE.SET_ALL);
+      setTimeout(() => {
+        if (Settings.ensureEnable()) {
+          Backend.throwSuspendEvt()
+        }
+        Backend.applySettings(APPLYTYPE.SET_ALL);
+      }, 10000)
     });
     PluginManager.state = PluginState.RUN;
   }


### PR DESCRIPTION
问题背景：
机型：Rog Ally，系统：HoloIso or ChimeraOS。
1. 插件设置限制 5W TDP。
2. Rog Ally 进入睡眠。
3. 按键唤醒，TDP 会涨到 20W 左右，也就是 5W TDP 限制失效了。

分析思路：
1. 根据插件日志，唤醒的时候插件的确调用了 SetTDP 逻辑，并调用 RjzenAdj。
2. 看了 RjzenAdj 的文档，怀疑是唤醒的时候底层 RjzenAdj 因为系统级别某种功耗调度未生效。

解决方案：
1. 在唤醒的时候，避开系统底层功耗调度，延迟一下再调用 SetTDP。
2. 尝试延迟 1S，无效。
3. 尝试延迟 10S，生效。表现上还是会上升到 20W 左右，但是 10S 之后会重新限制到 5W。

意义：
解决失效问题，方便用户持续使用 TDP 限制。

ps：10S还有个好处，万一限制的太低了，打不开侧边栏，也可以利用这个间隙尝试打开侧边栏恢复限制。不过你们可以考虑时间问题，或者其他方案。总之这个避开是有效的，具体底层我也不是很清楚。