### PR TITLE
Remove unused import

### DIFF
--- a/backend/sysInfo.py
+++ b/backend/sysInfo.py
@@ -4,7 +4,6 @@ import threading
 import time
 import os
 import asyncio
-from ec import EC
 from config import logging,SH_PATH,PRODUCT_NAME
 from config import GPU_DEVICE_PATH
 from helpers import get_user


### PR DESCRIPTION
This import doesn't appear to be needed in this file anymore. Removing this line seems to make it possible to run without portio.so if someone wants to (and go without fan control).