### PR TITLE
fix: regex pattern for OD_SCLK and OD_RANGE causes gpu control failure

### DIFF
--- a/backend/gpu.py
+++ b/backend/gpu.py
@@ -127,7 +127,7 @@ class GPUFreqNotifier ():
                 if os.path.exists(GPUFREQ_PATH):
                     freq_string = open(GPUFREQ_PATH,"r").read()
                     # 使用正则表达式提取频率信息
-                    od_sclk_matches = re.findall(r"OD_SCLK:\s*0:\s*(\d+)Mhz\s*1:\s*(\d+)Mhz", freq_string)
+                    od_sclk_matches = re.findall(r"OD_SCLK:?\s*0:\s*(\d+)Mhz\s*1:\s*(\d+)Mhz", freq_string)
                     if od_sclk_matches:
                         qfreqMin = int(od_sclk_matches[0][0])
                         qfreqMax = int(od_sclk_matches[0][1])
@@ -178,7 +178,7 @@ class GPUManager ():
             open(GPULEVEL_PATH,'w').write("manual")
             freq_string = open(GPUFREQ_PATH,"r").read()
             # 使用正则表达式提取频率信息
-            od_sclk_matches = re.findall(r"OD_RANGE:\s*SCLK:\s*(\d+)Mhz\s*(\d+)Mhz", freq_string)
+            od_sclk_matches = re.findall(r"OD_RANGE:?\s*SCLK:\s*(\d+)Mhz\s*(\d+)Mhz", freq_string)
             logging.debug(f"get_gpuFreqRange {od_sclk_matches[0][0]} {od_sclk_matches[0][1]}")
             if od_sclk_matches:
                 self.gpu_freqRange = [int(od_sclk_matches[0][0]),int(od_sclk_matches[0][1])]


### PR DESCRIPTION
由于`amdgpu`上游的不可靠 [[1]](https://github.com/ROCm/ROCK-Kernel-Driver/blob/cf8e29ea7ba831dbafe9530dcdad8d5a5682c6d4/drivers/gpu/drm/amd/pm/swsmu/smu13/smu_v13_0_0_ppt.c#L1333) [[2]](https://github.com/ROCm/ROCK-Kernel-Driver/blob/cf8e29ea7ba831dbafe9530dcdad8d5a5682c6d4/drivers/gpu/drm/amd/pm/swsmu/smu13/smu_v13_0_4_ppt.c#L496)，在*不同AMD架构/不同内核版本*（未确定）读取到的`pp_od_clk_voltage`格式存在差异（有无冒号），原正则表达式未能匹配导致`list index out of range`报错。

已测试设备：`AYANEO AIR Pro`，修复了其GPU控制失效的问题。