### PR TITLE
fix: add max-width and adjust tab wrapper margins

### DIFF
--- a/src/components/cpu.tsx
+++ b/src/components/cpu.tsx
@@ -1006,7 +1006,7 @@ export const CPUComponent: FC<{
     );
   }, []);
   return (
-    <div style={!isTab ? {} : { marginLeft: "-10px", marginRight: "-10px" }}>
+    <div style={!isTab ? {} : { marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
       {show && (
         <PanelSection title="CPU">
           {!isTab && (

--- a/src/components/fan.tsx
+++ b/src/components/fan.tsx
@@ -1500,7 +1500,7 @@ export const FANComponent: FC<{ isTab?: boolean }> = ({ isTab = false }) => {
   }, []);
   //<FANSelectProfileComponent/>
   return (
-    <div style={!isTab ? {} : { marginLeft: "-10px", marginRight: "-10px" }}>
+    <div style={!isTab ? {} : { marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
       {show && fanEnable.current && fanCount.current > 0 && (
         <PanelSection title="FAN">
           {!isTab && (

--- a/src/components/gpu.tsx
+++ b/src/components/gpu.tsx
@@ -450,7 +450,7 @@ export const GPUComponent: FC<{ isTab?: boolean }> = ({ isTab = false }) => {
     );
   }, []);
   return (
-    <div style={!isTab ? {} : { marginLeft: "-10px", marginRight: "-10px" }}>
+    <div style={!isTab ? {} : { marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
       {show && (
         <PanelSection title="GPU">
           {!isTab && (

--- a/src/components/more.tsx
+++ b/src/components/more.tsx
@@ -123,7 +123,7 @@ export const MoreComponent: FC<{ isTab?: boolean }> = ({ isTab = false }) => {
   }
 
   return (
-    <div style={!isTab ? {} : { marginLeft: "-10px", marginRight: "-10px" }}>
+    <div style={!isTab ? {} : { marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
       <PanelSection
         title={localizationManager.getString(localizeStrEnum.MORE) || "More"}
       >

--- a/src/components/power.tsx
+++ b/src/components/power.tsx
@@ -216,7 +216,7 @@ export const PowerComponent: FC<{ isTab?: boolean }> = ({ isTab = false }) => {
   }, [supportChargeLimit, isSupportSoftwareChargeLimit]);
 
   return (
-    <div style={!isTab ? {} : { marginLeft: "-10px", marginRight: "-10px" }}>
+    <div style={!isTab ? {} : { marginLeft: "-2.8vw", marginRight: "-2.8vw" }}>
       {show && (
         <PanelSection title="Power">
           {!isTab && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,6 +101,7 @@ const TabView: FC<{ show?: boolean }> = ({ show = true }) => {
           style={{
             height: "95%",
             width: "calc(100vw - 50px)",
+            maxWidth: "100%",
             marginTop: "-12px",
             position: "absolute",
             contain: "layout style paint",


### PR DESCRIPTION
aims to fix https://github.com/mengmeet/PowerControl/issues/106 

I used -2.8vw as margin because the tabs also have viewport based padding, and I added max-width: 100% so the layout doesn’t overflow the container anymore. 

this fixes it from breaking on Steam Client beta and maybe future Steam updates

I tested on my Zotac Zone with: 

- SteamOS Main + Steam Client Beta
- SteamOS Main + Steam Client Stable

PS: 

calc(100vw - 50px) could probably also be replaced with 94.4vw, but I left that out for now to keep the change small.

We could probably also pull the value from gamepadTabbedPageClasses.contentPadding and turn it into a matching negative margin, but I didn’t want to overcomplicate this 🤣 